### PR TITLE
Change type for $id from String to ID

### DIFF
--- a/gh-pr-draft
+++ b/gh-pr-draft
@@ -21,7 +21,7 @@ else
 fi
 
 MUTATION='
-  mutation($id: String!) {
+  mutation($id: ID!) {
     convertPullRequestToDraft(input: { pullRequestId: $id }) {
       pullRequest {
         id


### PR DESCRIPTION
# Problem

When running `gh pr-draft` it's throwing an error:

```
gh: Type mismatch on variable $id and argument pullRequestId (String! / ID!)
```

# Solution

- Changed the type for `$id` from `String` to `ID`
